### PR TITLE
get version from github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,9 +128,11 @@ RUN \
  install -Dm644 /tmp/patches/xcache.ini /etc/php5/conf.d/xcache.ini && \
  echo "**** install projectsend ****" && \
  rm /var/www/localhost/htdocs/index.html && \
+ PROJS_TAG=$(curl -sX GET "https://api.github.com/repos/projectsend/projectsend/releases/latest" \
+	| awk '/tag_name/{print $4;exit}' FS='[""]') && \
  curl -o \
  /tmp/ProjectSend.tar.gz -L \
-	"https://codeload.github.com/ignacionelson/ProjectSend/tar.gz/r1053" && \
+	"https://github.com/projectsend/projectsend/archive/$PROJS_TAG.tar.gz" && \
  tar -zxf \
 	/tmp/ProjectSend.tar.gz --strip-components=1 -C /var/www/localhost/htdocs/ && \
  mv /var/www/localhost/htdocs/upload /defaults/ && \

--- a/README.md
+++ b/README.md
@@ -84,5 +84,6 @@ More info at [ProjectSend][appurl].
 
 ## Versions
 
++ **11.06.17:** Fetch version from github.
 + **09.12.17:** Rebase to alpine 3.7.
 + **13.06.17:** Initial Release.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

since the existing download link gets the latest version regardless of the version number (eg rxxx) appended to the link, using github to explicitly get the latest should stop spurious PR's to update the version etc when is not needed.

still have the problem with #7 that this PR does not address but neither does it actually cause the issue as it pre-existing with the latest builds etc since r1053 