### PR TITLE
Implemented language and template installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,10 @@ RUN \
 # add local files
 COPY root/ /
 
+# languages and templates
+RUN chmod +x /run.sh                                                                                                                                
+CMD /run.sh
+
 # ports and volumes
 EXPOSE 80
-VOLUME /config /data
+VOLUME /config /data /templates

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -59,6 +59,10 @@ RUN \
 # add local files
 COPY root/ /
 
+# languages and templates
+RUN chmod +x /run.sh                                                                                                                                
+CMD /run.sh
+
 # ports and volumes
 EXPOSE 80
-VOLUME /config /data
+VOLUME /config /data /templates

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -59,6 +59,10 @@ RUN \
 # add local files
 COPY root/ /
 
+# languages and templates
+RUN chmod +x /run.sh                                                                                                                                
+CMD /run.sh
+
 # ports and volumes
 EXPOSE 80
-VOLUME /config /data
+VOLUME /config /data /templates

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ services:
       - PGID=1000
       - TZ=Europe/London
       - MAX_UPLOAD=<5000>
-      - PS_INSTALL_LANGUAGES=de,fr
     volumes:
       - <path to data>:/config
       - <path to data>:/data
@@ -101,7 +100,6 @@ docker run -d \
   -e PGID=1000 \
   -e TZ=Europe/London \
   -e MAX_UPLOAD=<5000> \
-  -e PS_INSTALL_LANGUAGES=de,fr \
   -p 80:80 \
   -v <path to data>:/config \
   -v <path to data>:/data \
@@ -120,11 +118,8 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London. |
 | `-e MAX_UPLOAD=<5000>` | To set maximum upload size (in MB), default if unset is 5000. |
-| `-e PS_INSTALL_LANGUAGES=de,fr` | Optionally install additional languages, separated by commas. English (en) is always installed. |
-| `-e PS_INSTALL_TEMPLATES=template1,https://test.com/template.zip;template2` | Optionally install additional templates, separated by commas, from /templates (syntax: foldername) or online zip files (syntax: url;foldername).  |
 | `-v /config` | Where to store projectsend config files. |
 | `-v /data` | Where to store files to share. |
-| `-v /templates` | Where to store local templates to install. |
 
 ## Environment variables from files (Docker secrets)
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ services:
       - PGID=1000
       - TZ=Europe/London
       - MAX_UPLOAD=<5000>
+      - PS_INSTALL_LANGUAGES=de,fr
     volumes:
       - <path to data>:/config
       - <path to data>:/data
@@ -100,6 +101,7 @@ docker run -d \
   -e PGID=1000 \
   -e TZ=Europe/London \
   -e MAX_UPLOAD=<5000> \
+  -e PS_INSTALL_LANGUAGES=de,fr \
   -p 80:80 \
   -v <path to data>:/config \
   -v <path to data>:/data \
@@ -118,8 +120,11 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London. |
 | `-e MAX_UPLOAD=<5000>` | To set maximum upload size (in MB), default if unset is 5000. |
+| `-e PS_INSTALL_LANGUAGES=de,fr` | Optionally install additional languages, separated by commas. English (en) is always installed. |
+| `-e PS_INSTALL_TEMPLATES=template1,https://test.com/template.zip;template2` | Optionally install additional templates, separated by commas, from /templates (syntax: foldername) or online zip files (syntax: url;foldername).  |
 | `-v /config` | Where to store projectsend config files. |
 | `-v /data` | Where to store files to share. |
+| `-v /templates` | Where to store local templates to install. |
 
 ## Environment variables from files (Docker secrets)
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -58,6 +58,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "05.11.21:", desc: "Add language and template install option."}
   - { date: "24.06.21:", desc: "Rebasing to alpine 3.14, switch to nginx"}
   - { date: "23.01.21:", desc: "Rebasing to alpine 3.13." }
   - { date: "01.06.20:", desc: "Rebasing to alpine 3.12." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -25,10 +25,14 @@ param_usage_include_env: true
 param_env_vars:
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London." }
   - { env_var: "MAX_UPLOAD", env_value: "<5000>", desc: "To set maximum upload size (in MB), default if unset is 5000." }
+  - { env_var: "PS_INSTALL_LANGUAGES", env_value: "de,fr", desc: "Optionally install additional languages, separated by commas. English (en) is always installed." }
+  - { env_var: "PS_INSTALL_TEMPLATES", env_value: "template1,https://test.com/template.zip;template2", desc: "Optionally install additional templates, separated by commas, from /templates (syntax: foldername) or online zip files (syntax: url;foldername)." }
 param_usage_include_vols: true
 param_volumes:
   - { vol_path: "/config", vol_host_path: "<path to data>", desc: "Where to store projectsend config files." }
   - { vol_path: "/data", vol_host_path: "<path to data>", desc: "Where to store files to share." }
+  - { vol_path: "/templates", vol_host_path: "<path to data>", desc: "Where to store local templates for installation." }
+
 param_usage_include_ports: true
 param_ports:
   - { external_port: "80", internal_port: "80", port_desc: "WebUI" }

--- a/root/run.sh
+++ b/root/run.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -e
+
+if [ ! -z "${PS_INSTALL_LANGUAGES}" ]; then
+  OLDIFS=$IFS
+  IFS=','
+  for language in ${PS_INSTALL_LANGUAGES}; do
+    IFS=$OLDIFS
+    echo "**** install language: ${language} ****"
+    curl -s -o "/tmp/${language}.zip" -L "https://www.projectsend.org/translations/get.php?lang=${language}"
+    unzip -o "/tmp/${language}.zip" -d /app/projectsend;
+  done
+  echo "**** cleanup ****"
+  rm -rf /tmp/*
+fi
+
+if [ ! -z "${PS_INSTALL_TEMPLATES}" ]; then
+  OLDIFS=$IFS
+  IFS=','
+  for template in ${PS_INSTALL_TEMPLATES}; do
+    IFS=$OLDIFS
+    if [[ $template =~ .*\;.* ]]; then
+        templateUrl=$(echo "$template" | cut -d';' -f 1)
+        templateInstallFolder=$(echo "$template" | cut -d';' -f 2)
+        echo "**** install template: ${templateInstallFolder} ****"
+        curl -s -o "/tmp/${templateInstallFolder}.zip" -L "${templateUrl}"
+        unzip -o "/tmp/${templateInstallFolder}.zip" -d /app/projectsend/templates/
+    else
+        echo "**** install template: ${template} ****"
+        cp -R "/templates/${template}" /app/projectsend/templates/
+    fi
+  done
+  echo "**** cleanup ****"
+  rm -rf /tmp/*
+fi
+
+while :; do :; done & kill -STOP $! && wait $!


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-projectsend/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
ProjectSend now provides [translations on their website](https://www.projectsend.org/translations/) as zip file. Unfortunately I couldn't find an easy solution for importing the contents of those zip files into the appropriate directories. (volume mounts disturbed the build process of the image) So I modified your Dockerfile to automatically install languages from the website by given `PS_INSTALL_LANGUAGES` environment variable. This variable can be a comma separated list of language short codes (as provided on the translations' website).

I also figured that the same problem applies if you want to install your own template. Using the same logic `PS_INSTALL_TEMPLATES` is provided. It can consist of a comma separated list of both local template folders (in the new `/templates` volume mount) and/or zip file url & folder/template name combinations. The latter have to be provided as following: `https://test.com/template.zip;foldername`.

**Please note:** You might want to optimize the readme-vars.yml, I couldn't come up with the best solution on how to document the new options.

## Benefits of this PR and context:
It allows users to easily install additional languages and templates, which isn't possible yet.

## How Has This Been Tested?
I did various manual tests and tried to avoid common mistakes. Still, I'm pretty sure there are edge cases. Feel free to optimize my code.

## Source / References:
I took inspiration from the Dockerfile of the Grafana repository, especially this file: https://github.com/grafana/grafana/blob/main/packaging/docker/run.sh. Thanks!